### PR TITLE
Change command for moving root filesystem to @ subvolume

### DIFF
--- a/content/linux/pop-os-btrfs-22-04.md
+++ b/content/linux/pop-os-btrfs-22-04.md
@@ -201,8 +201,9 @@ Now we will first create the subvolume `@` and move all files and folders from t
 ```sh
 btrfs subvolume create /mnt/@
 # Create subvolume '/mnt/@'
-mv /mnt/* /mnt/@/
-# mv: cannot move '/mnt/@' to a subdirectory of itself, '/mnt/@/@' (ignore this)
+cd /mnt
+ls | grep -v @ | xargs mv -t @
+# this moves all files that don't have "@" in the name to the @/ folder
 ls -a /mnt
 # . .. @
 ```


### PR DESCRIPTION
The old command doesn't take into consideration cases when the user already has subvolumes under /mnt, for example, if the user is reinstalling the operating system. This new command makes sure to ignore all subvolumes that follow the convention (if they start with an @ sign). Performance shouldn't be a concern since all users following this guide will have a small number of files to move due to having a fresh operating system.